### PR TITLE
Add option to update search register mark#SearchNext()

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,11 @@ history; if you don't want that, remove the corresponding symbols from:
 
     let g:mwHistAdd = '/@'
 
+By default, searches with <Leader>\* and <Leader>/ doesn't change the behavior
+of the default n/N movement. To change the search register: 
+
+    let g:mwHistSearch = 1
+
 To enable the automatic restore of marks from a previous Vim session:
 
     let g:mwAutoLoadMarks = 1

--- a/autoload/mark.vim
+++ b/autoload/mark.vim
@@ -766,6 +766,9 @@ function! mark#SearchNext( isBackward, ... )
 	" Use the provided search type or choose depending on last use of
 	" <Plug>MarkSearchCurrentNext / <Plug>MarkSearchAnyNext.
 	call call(a:0 ? a:1 : (s:lastSearch == -1 ? 'mark#SearchAnyMark' : 'mark#SearchCurrentMark'), [a:isBackward])
+	if g:mwHistSearch && a:0 && a:1 == 'mark#SearchCurrentMark'
+		let @/=l:markText
+	endif
 	return 1
 endfunction
 

--- a/doc/mark.txt
+++ b/doc/mark.txt
@@ -420,6 +420,11 @@ By default, any marked words are also added to the search (/) and input (@)
 history; if you don't want that, remove the corresponding symbols from: >
     let g:mwHistAdd = '/@'
 <
+								 *g:mwHistSearch*
+By default, searches with <Leader>* and <Leader>/ doesn't change the behavior
+of the default n/N movement.  To change the search register: >
+    let g:mwHistSearch = 1
+<
 							   *g:mwAutoLoadMarks*
 To enable the automatic restore of marks from a previous Vim session: >
     let g:mwAutoLoadMarks = 1

--- a/plugin/mark.vim
+++ b/plugin/mark.vim
@@ -29,6 +29,10 @@ if ! exists('g:mwHistAdd')
 	let g:mwHistAdd = '/@'
 endif
 
+if ! exists('g:mwHistSearch')
+	let g:mwHistSearch = 0
+endif
+
 if ! exists('g:mwAutoLoadMarks')
 	let g:mwAutoLoadMarks = 0
 endif


### PR DESCRIPTION
I've been using the following mappings for quite some time:

```
nmap * <Plug>MarkSearchOrCurNext
nmap # <Plug>MarkSearchOrCurPrev
```

But I often forget that after using these mappings on a mark the next use of the default <kbd>n</kbd> or <kbd>N</kbd> jumps to the previous non-mark search.

I think adding this option would make the behavior of these keys more intuitive.