### PR TITLE
Clarify creating custom mappings in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,7 +471,8 @@ would like to change their relative priorities. The default is negative to
 step back behind the default search highlighting.
 
 If you want no or only a few of the available mappings, you can completely
-turn off the creation of the default mappings by defining:
+turn off the creation of the default mappings by defining (before the plugin
+is loaded):
 
     :let g:mw_no_mappings = 1
 

--- a/doc/mark.txt
+++ b/doc/mark.txt
@@ -471,7 +471,8 @@ step back behind the default search highlighting.
 
 							    *g:mw_no_mappings*
 If you want no or only a few of the available mappings, you can completely
-turn off the creation of the default mappings by defining: >
+turn off the creation of the default mappings by defining (before the plugin
+is loaded): >
     :let g:mw_no_mappings = 1
 This saves you from mapping dummy keys to all unwanted mapping targets.
 						  *mark-mappings* *mark-remap*


### PR DESCRIPTION
I believe existing version of README.md is not clear enough. For example it says that you need to do custom mappings before sourcing the plugin's script. But in fact you need to assign 1 to `g:mw_no_warnings` before sourcing the script. In this case it does not matter at which point to do those custom mappings (although I prefer to do that after sourcing the script).

In this PR I'm trying to clarify this topic in README.md